### PR TITLE
Update peerDependencies

### DIFF
--- a/projects/ngx-pinch-zoom/package.json
+++ b/projects/ngx-pinch-zoom/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/drozhzhin-n-e/ngx-pinch-zoom/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^11.1.2",
-    "@angular/core": "^11.1.2"
+    "@angular/common": "^12.0.0",
+    "@angular/core": "^12.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"


### PR DESCRIPTION
The peerDependencies of angular must be set to 12 in order to install this plugin in an angular 12 project.